### PR TITLE
[feature] exposes options arg for link-preview-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Please refer to the [react-native-url-preview example](https://github.com/maherz
 | titleNumberOfLines       |    NO     | 2                          | `number`  | self explanatory i believe                             |
 | descriptionNumberOfLines |    NO     | Ipad?4:3                   | `number`  | self explanatory i believe                             |
 | imageProps               |    NO     | `{ resizeMode: "contain"}` | `object`  | you can pass a custom props to image                   |
+| requestOptions           |    NO     | `{}`                       | `object`  | pass additional options to url preview request
 | onLoad                   |    NO     | `() => {}`                 | `function`| callback called when url preview data is loaded          |
 | onError                  |    NO     | `() => {}`                 | `function`| callback called if url preview fails to load           |
-
 ## Credits 🐜
 
 - Thanks to [marouan frih](https://github.com/Madm0x) for the REGEX

--- a/index.js
+++ b/index.js
@@ -15,12 +15,12 @@ export default class RNUrlPreview extends React.PureComponent {
       linkFavicon: undefined,
       linkImg: undefined,
     };
-    this.getPreview(props.text);
+    this.getPreview(props.text, props.requestOptions);
   }
 
-  getPreview = text => {
+  getPreview = (text, options) => {
     const {onError, onLoad} = this.props;
-    getLinkPreview(text)
+    getLinkPreview(text, options)
       .then(data => {
         onLoad(data);
         this.setState({
@@ -149,6 +149,7 @@ RNUrlPreview.defaultProps = {
   onLoad: () => {},
   onError: () => {},
   text: null,
+  requestOptions: {},
   containerStyle: {
     backgroundColor: 'rgba(239, 239, 244,0.62)',
     alignItems: 'center',
@@ -207,4 +208,9 @@ RNUrlPreview.propTypes = {
   titleNumberOfLines: Text.propTypes.numberOfLines,
   descriptionStyle: Text.propTypes.style,
   descriptionNumberOfLines: Text.propTypes.numberOfLines,
+  requestOptions: PropTypes.shape({
+    headers: PropTypes.objectOf(PropTypes.string),
+    imagesPropertyType: PropTypes.string,
+    proxyUrl: PropTypes.string 
+  })
 };


### PR DESCRIPTION
link-preview-js allows for passing an `options` arg to `getPreview()`: https://github.com/ospfranco/link-preview-js#options

One use case for this is that setting `options.headers["user-agent"] = "googlebot"` allows for getting better previews for YouTube URLs.