### PR TITLE
Remove font family

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,6 @@ RNUrlPreview.defaultProps = {
     marginRight: 10,
     marginBottom: 5,
     alignSelf: 'flex-start',
-    fontFamily: 'Helvetica',
   },
   titleNumberOfLines: 2,
   descriptionStyle: {
@@ -188,7 +187,6 @@ RNUrlPreview.defaultProps = {
     color: '#81848A',
     marginRight: 10,
     alignSelf: 'flex-start',
-    fontFamily: 'Helvetica',
   },
   descriptionNumberOfLines: Platform.isPad ? 4 : 3,
   imageProps: {resizeMode: 'contain'},


### PR DESCRIPTION
As Helvetica font needs to be loaded through `Font.loadAsync` it will fail to load (unless specifically loaded before the app initializes).

Removing it will just fall back to default font which is what is happening now it just won't throw errors in the console about it.

![image](https://user-images.githubusercontent.com/8104698/106303502-7dacfe00-625a-11eb-9a6c-56b131603573.png)
